### PR TITLE
Add fields to model Deviseuser

### DIFF
--- a/app/models/deviseuser.rb
+++ b/app/models/deviseuser.rb
@@ -4,5 +4,6 @@ class Deviseuser < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :playlists
-  
+  validates_uniqueness_of :name, scope: [:spotifyid]
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
 class User < ApplicationRecord
-    validates_uniqueness_of :name, scope: [:spotifyid]
+    # validates_uniqueness_of :name, scope: [:spotifyid]
 
 end

--- a/db/migrate/20211104115432_add_details_to_deviseusers.rb
+++ b/db/migrate/20211104115432_add_details_to_deviseusers.rb
@@ -1,0 +1,7 @@
+class AddDetailsToDeviseusers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :deviseusers, :spotify_access_token, :text
+    add_column :deviseusers, :spotifyid, :string
+    add_column :deviseusers, :name, :string
+  end
+end

--- a/db/migrate/20211104115612_add_index_to_deviseusers_name_spotifyid.rb
+++ b/db/migrate/20211104115612_add_index_to_deviseusers_name_spotifyid.rb
@@ -1,0 +1,5 @@
+class AddIndexToDeviseusersNameSpotifyid < ActiveRecord::Migration[6.0]
+  def change
+    add_index :deviseusers, [:name, :spotifyid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_04_113123) do
+ActiveRecord::Schema.define(version: 2021_11_04_115612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,11 @@ ActiveRecord::Schema.define(version: 2021_11_04_113123) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "spotify_access_token"
+    t.string "spotifyid"
+    t.string "name"
     t.index ["email"], name: "index_deviseusers_on_email", unique: true
+    t.index ["name", "spotifyid"], name: "index_deviseusers_on_name_and_spotifyid", unique: true
     t.index ["reset_password_token"], name: "index_deviseusers_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
We've added some fields to the Deviseuser model  : "spotify_access_token", "spotifyid" 
On the same model , we've also added an index between "name" & "spotifyid"